### PR TITLE
Fixed world-screen coordinate bug + clean-up

### DIFF
--- a/examples/simple/top_down.py
+++ b/examples/simple/top_down.py
@@ -9,8 +9,8 @@ import systems
 def main():
     # screen setup
     pygame.init()
-    size = 0, 0
-    screen = pygame.display.set_mode(size, pygame.FULLSCREEN)
+    size = 800, 400
+    screen = pygame.display.set_mode(size)
 
     width, height = screen.get_size()
 
@@ -74,7 +74,7 @@ def main():
                 sys.exit()
 
         # handle events and move player
-        player.rotate_to_mouse()
+        player.rotate_to_target(main_cam.reverse(pygame.mouse.get_pos()))
         keys = pygame.key.get_pressed()
         if keys[pygame.K_w]:
             player.move(0, -player.speed, colliders)

--- a/systems/camera.py
+++ b/systems/camera.py
@@ -14,6 +14,10 @@ class Camera(object):
         # applies the camera offset to the target sprite by aligning it's rect with the camera rect
         return target.rect.move(self.state.topleft)
 
+    def reverse(self, pos):
+        # converts screen coordinates to world coordinates
+        return pos[0] - self.state.left, pos[1] - self.state.top
+
     def update(self, target):
         # updates the camera state to follow the target sprite using a selected function
         self.state = self.func(self.state, target.rect, self.view_size)

--- a/systems/entities.py
+++ b/systems/entities.py
@@ -219,14 +219,13 @@ class Player(LivingSprite):
                 yield (x * s, x * s)
             s *= -1
 
-    def rotate_to_mouse(self):
-        mouse_x, mouse_y = pygame.mouse.get_pos()
+    def rotate_to_target(self, target):
+        # get vector between player and target
+        vector = (self.rect.x - target[0], self.rect.y - target[1])
 
-        # get vector between player and mouse
-        mouse_vector = (self.rect.x - mouse_x, self.rect.y - mouse_y)
-
+        # calculate angle between player and target
         try:
-            theta = -math.degrees(math.atan2(mouse_vector[1], mouse_vector[0])) + 90
+            theta = -math.degrees(math.atan2(vector[1], vector[0])) + 90
         except ZeroDivisionError:
             theta = 0
 

--- a/systems/spritesheets.py
+++ b/systems/spritesheets.py
@@ -6,8 +6,7 @@ class SpriteSheet(object):
         try:
             self.sheet = pygame.image.load(filename).convert_alpha()
         except pygame.error as e:
-            print("Could not load spritesheet:", filename)
-            raise SystemExit(e)
+            raise SystemExit(e, "Could not load spritesheet:" + filename)
 
     def image_at(self, selector):
         rect = pygame.Rect(selector)


### PR DESCRIPTION
Added reverse method to camera class to convert screen coordinates to world coordinates and applied to mouse position before rotation. The player now correctly faces the mouse regardless of the player's position in the world.

Also cleanup the spritesheet loader error handler slightly.